### PR TITLE
fix: duplicate data issue when importing

### DIFF
--- a/src/helpers/ImportHelpers/ImportBreezeZipHelper.ts
+++ b/src/helpers/ImportHelpers/ImportBreezeZipHelper.ts
@@ -70,6 +70,8 @@ const readBreezeZip = async (file: File): Promise<ImportDataInterface> => {
 }
 
 const loadGroups = (data: any) => {
+  groups = [];
+  groupMembers = [];
   const xlsGroups = Object.keys(data)
   xlsGroups.forEach((groupName, i) => {
     getOrCreateGroup(groups, { importKey: i.toString(), serviceTimeKey: null, startDate: null, endDate: null, name: groupName } as ImportGroupInterface);
@@ -96,6 +98,10 @@ const getOrCreateGroup = (groups: ImportGroupInterface[], data: ImportGroupInter
 }
 
 const loadDonations = (data: any) => {
+  batches = [];
+  donations = [];
+  funds = [];
+  fundDonations = [];
   for (let i = 0; i < data["Total Contributions"].length; i++) {
     let d = data["Total Contributions"][i];
     if (d.Amount !== undefined) {
@@ -119,6 +125,8 @@ const assignHousehold = (households: ImportHouseholdInterface[], person: ImportP
 }
 
 const loadPeople = (data: any) => {
+  people = [];
+  households = [];
   const xlssheets = Object.keys(data)
   xlssheets.forEach(sheet => {
     for (let i = 0; i < data[sheet].length; i++) {

--- a/src/helpers/ImportHelpers/ImportChumsZipHelper.ts
+++ b/src/helpers/ImportHelpers/ImportChumsZipHelper.ts
@@ -69,30 +69,38 @@ const readChumsZip = async (file: File): Promise<ImportDataInterface> => {
 }
 
 const loadAnswers = (data: any) => {
+  answers = [];
   for (let i = 0; i < data.length; i++) if (data[i].value !== undefined) {
     answers.push(data[i]);
   }
 }
 
 const loadFormSubmissions = (data: any) => {
+  formSubmissions = [];
   for (let i = 0; i < data.length; i++) if (data[i].personKey !== undefined) {
     formSubmissions.push(data[i]);
   }
 }
 
 const loadQuestions = (data: any) => {
+  questions = [];
   for (let i = 0; i < data.length; i++) if (data[i].title !== undefined) {
     questions.push(data[i]);
   }
 }
 
 const loadForms = (data: any) => {
+  forms = [];
   for (let i = 0; i < data.length; i++) if (data[i].name !== undefined) {
     forms.push(data[i]);
   }
 }
 
 const loadDonations = (data: any) => {
+  batches = [];
+  funds = [];
+  donations = [];
+  fundDonations = [];
   for (let i = 0; i < data.length; i++) if (data[i].amount !== undefined) {
     let d = data[i];
     let batch = ImportHelper.getOrCreateBatch(batches, d.batch, new Date(d.date));
@@ -107,6 +115,9 @@ const loadDonations = (data: any) => {
 }
 
 const loadAttendance = (data: any, tmpServiceTimes: ImportServiceTimeInterface[]) => {
+  sessions = [];
+  visits = [];
+  visitSessions = [];
   for (let i = 0; i < data.length; i++) if (data[i].personKey !== undefined && data[i].groupKey !== undefined) {
     let session = ImportHelper.getOrCreateSession(sessions, new Date(data[i].date), data[i].groupKey, data[i].serviceTimeKey);
     let visit = ImportHelper.getOrCreateVisit(visits, data[i], tmpServiceTimes);
@@ -122,6 +133,9 @@ const loadAttendance = (data: any, tmpServiceTimes: ImportServiceTimeInterface[]
 }
 
 const loadServiceTimes = (data: any) => {
+  campuses = [];
+  services = [];
+  serviceTimes = [];
   for (let i = 0; i < data.length; i++) if (data[i].time !== undefined) {
     let campus = ImportHelper.getOrCreateCampus(campuses, data[i].campus);
     let service = ImportHelper.getOrCreateService(services, data[i].service, campus);
@@ -131,6 +145,8 @@ const loadServiceTimes = (data: any) => {
 }
 
 const loadGroups = (data: any) => {
+  groups = [];
+  groupServiceTimes = [];
   for (let i = 0; i < data.length; i++) if (data[i].name !== undefined) {
     let group = ImportHelper.getOrCreateGroup(groups, data[i]);
     if (group !== null && group.serviceTimeKey !== undefined && group.serviceTimeKey !== null) {
@@ -142,10 +158,13 @@ const loadGroups = (data: any) => {
 }
 
 const loadGroupMembers = (data: any) => {
+  groupMembers = [];
   for (let i = 0; i < data.length; i++) if (data[i].groupKey !== undefined) groupMembers.push(data[i] as ImportGroupMemberInterface);
 }
 
 const loadPeople = (data: any, zip: any) => {
+  people = [];
+  households = [];
   for (let i = 0; i < data.length; i++) {
     if (data[i].lastName !== undefined) {
       const p = data[i] as ImportPersonInterface;


### PR DESCRIPTION
Problem: When importing, once you select the file, you'll see that data in the preview tab. Now, for some reason, you want to start over before exporting that data and click on the Start Over button and select a new/same file. Now in the preview tab, you'll see the old/previous file data along with the new data.